### PR TITLE
test_cli_error in server test fix

### DIFF
--- a/q1/tests/test_server_q1.py
+++ b/q1/tests/test_server_q1.py
@@ -135,6 +135,7 @@ def test_cli_error():
     server = socket.socket()
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.bind(_SERVER_ADDRESS)
+    server.listen()
     process = subprocess.Popen(
         ['python', _SERVER_PATH, f'{host}:{port}'],
         stdout = subprocess.PIPE,

--- a/q2/tests/test_server_q2.py
+++ b/q2/tests/test_server_q2.py
@@ -135,6 +135,7 @@ def test_cli_error():
     server = socket.socket()
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.bind(_SERVER_ADDRESS)
+    server.listen()
     process = subprocess.Popen(
         ['python', _SERVER_PATH, f'{host}:{port}'],
         stdout = subprocess.PIPE,


### PR DESCRIPTION
Test cannot be satisfied since the server the test create doesn't start to listen. This means that the port is still available. Adding server.listen() resolves the issue