### PR TITLE
Fix q3/test_server_q3.py - expect newline when reading thought

### DIFF
--- a/q3/tests/test_server_q3.py
+++ b/q3/tests/test_server_q3.py
@@ -66,10 +66,10 @@ def test_timestamp(data_dir):
 def test_thought(data_dir):
     _upload_thought(_USER_1, _TIMESTAMP_1, _THOUGHT_1)
     thought_path = _get_path(data_dir, _USER_1, _TIMESTAMP_1)
-    assert thought_path.read_text() == _THOUGHT_1
+    assert thought_path.read_text() .rstrip() == _THOUGHT_1
     _upload_thought(_USER_2, _TIMESTAMP_2, _THOUGHT_2)
     thought_path = _get_path(data_dir, _USER_2, _TIMESTAMP_2)
-    assert thought_path.read_text() == _THOUGHT_2
+    assert thought_path.read_text().rstrip() == _THOUGHT_2
 
 
 def test_partial_data(data_dir):
@@ -80,7 +80,7 @@ def test_partial_data(data_dir):
             connection.sendall(bytes([c]))
             time.sleep(0.01)
     thought_path = _get_path(data_dir, _USER_1, _TIMESTAMP_1)
-    assert thought_path.read_text() == _THOUGHT_1
+    assert thought_path.read_text().rstrip() == _THOUGHT_1
 
 
 def test_race_condition(data_dir):


### PR DESCRIPTION
from Exercise 1: Introduction -
For example, if user 1 also thought I'm sleepy at the same time, the file /tmp/data/1/2019-10-25_15-12-05.txt **should contain:
I'm hungry
I'm sleepy**

So it looks like a newline is expected after each thought.