### PR TITLE
fix conflict in server files

### DIFF
--- a/q1/tests/test_server_q1.py
+++ b/q1/tests/test_server_q1.py
@@ -12,7 +12,7 @@ import time
 
 import pytest
 
-import server
+from q1 import server
 
 
 _SERVER_ADDRESS = '127.0.0.1', 5000

--- a/q2/tests/test_server_q2.py
+++ b/q2/tests/test_server_q2.py
@@ -12,7 +12,7 @@ import time
 
 import pytest
 
-import server
+from q2 import server
 
 
 _SERVER_ADDRESS = '127.0.0.1', 5000

--- a/q3/tests/test_server_q3.py
+++ b/q3/tests/test_server_q3.py
@@ -12,7 +12,7 @@ import time
 
 import pytest
 
-import server
+from q3 import server
 
 
 _SERVER_ADDRESS = '127.0.0.1', 5000


### PR DESCRIPTION
When you run pytest to run multiple tests, for example:
```
$ pytest q1 q2
```
pytest takes server from the first directory it finds test. In the example above, q2 tests will run `server.py` from q1 directory.